### PR TITLE
add skip button on mobile option

### DIFF
--- a/carcode-wp-plugin.php
+++ b/carcode-wp-plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: CarCode WordPress Plugin
  * Plugin URI: https://github.com/abrahamcuenca/carcode-wp-plugin
  * Description: This plugin allows you to add a CarCode widget on to your WordPress site. This plugin does not allow you to display the CarCode widget only on certain pages such as VDP or SRP. In order to add the CarCode widget to certain pages add a custom block and paste in the widget code provided by the Widgets Implementation team.
- * Version: 1.0.0
+ * Version: 1.3.0
  * requires at least: 5.2
  * Requires PHP: 7.1
  * Author: Abraham Cuenca
@@ -29,7 +29,7 @@
  */
 
 if (!defined("ABSPATH")) {
-  exit;
+    exit;
 }
 
 add_action("admin_menu", "carcode_wp_plugin_add_admin_menu", 1);
@@ -37,95 +37,130 @@ add_action("admin_init", "carcode_wp_plugin_settings_init", 2);
 
 function carcode_wp_plugin_add_admin_menu()
 {
-  add_menu_page(
-    "CarCode Widget",
-    "CarCode Widget Config",
-    "manage_options",
-    "carcode_wp_plugin",
-    "carcode_wp_plugin_options_page",
-    "dashicons-car",
-    20
-  );
+    add_menu_page(
+        "CarCode Widget",
+        "CarCode Widget Config",
+        "manage_options",
+        "carcode_wp_plugin",
+        "carcode_wp_plugin_options_page",
+        "dashicons-car",
+        20
+    );
 }
 
 function carcode_wp_plugin_settings_init()
 {
-  register_setting("carcode_wp_plugin_page", "carcode_wp_plugin_settings", "carcode_wp_plugin_validate");
+    register_setting("carcode_wp_plugin_page", "carcode_wp_plugin_settings", "carcode_wp_plugin_validate");
 
-  add_settings_section(
-    "carcode_wp_plugin_page_section",
-    "CarCode WordPress Plugin",
-    "carcode_wp_plugin_settings_section_callback",
-    "carcode_wp_plugin_page"
-  );
+    add_settings_section(
+        "carcode_wp_plugin_page_section",
+        "CarCode WordPress Plugin",
+        "carcode_wp_plugin_settings_section_callback",
+        "carcode_wp_plugin_page"
+    );
 
-  add_settings_field(
-    "carcode_wp_plugin_widget_type",
-    "CarCode Widget Type",
-    "carcode_wp_plugin_widget_type_render",
-    "carcode_wp_plugin_page",
-    "carcode_wp_plugin_page_section"
-  );
+    add_settings_field(
+        "carcode_wp_plugin_widget_type",
+        "CarCode Widget Type",
+        "carcode_wp_plugin_widget_type_render",
+        "carcode_wp_plugin_page",
+        "carcode_wp_plugin_page_section"
+    );
 
-  add_settings_field(
-    "carcode_wp_plugin_carcode_id",
-    "CarCode ID",
-    "carcode_wp_plugin_carcode_id_render",
-    "carcode_wp_plugin_page",
-    "carcode_wp_plugin_page_section"
-  );
+    add_settings_field(
+        "carcode_wp_plugin_carcode_id",
+        "CarCode ID",
+        "carcode_wp_plugin_carcode_id_render",
+        "carcode_wp_plugin_page",
+        "carcode_wp_plugin_page_section"
+    );
 
-  add_settings_field(
-    "carcode_wp_plugin_eas_id",
-    "Content-Container (EAS) ID",
-    "carcode_wp_plugin_eas_id_render",
-    "carcode_wp_plugin_page",
-    "carcode_wp_plugin_page_section"
-  );
+    add_settings_field(
+        "carcode_wp_plugin_eas_id",
+        "Content-Container (EAS) ID",
+        "carcode_wp_plugin_eas_id_render",
+        "carcode_wp_plugin_page",
+        "carcode_wp_plugin_page_section"
+    );
+
+    add_settings_field(
+        "carcode_wp_plugin_skip_button_mobile_id",
+        "Skip button on mobile devices",
+        "carcode_wp_plugin_skip_button_mobile_id_render",
+        "carcode_wp_plugin_page",
+        "carcode_wp_plugin_page_section"
+    );
 }
 
 function carcode_wp_plugin_validate($input)
 {
-  return array_map("wp_filter_nohtml_kses", (array)$input);
+    $validated = array();
+
+    // Set defaults for all settings
+    $validated['carcode_wp_plugin_widget_type'] = isset($input['carcode_wp_plugin_widget_type']) ? wp_filter_nohtml_kses($input['carcode_wp_plugin_widget_type']) : '';
+    $validated['carcode_wp_plugin_carcode_id'] = isset($input['carcode_wp_plugin_carcode_id']) ? wp_filter_nohtml_kses($input['carcode_wp_plugin_carcode_id']) : '';
+    $validated['carcode_wp_plugin_eas_id'] = isset($input['carcode_wp_plugin_eas_id']) ? wp_filter_nohtml_kses($input['carcode_wp_plugin_eas_id']) : '';
+    $validated['carcode_wp_plugin_skip_button_mobile_id'] = isset($input['carcode_wp_plugin_skip_button_mobile_id']) ? '1' : '0';
+
+    return $validated;
 }
 
 function carcode_wp_plugin_widget_type_render()
 {
-  $options = get_option("carcode_wp_plugin_settings");
-  $widget_type_option = $options["carcode_wp_plugin_widget_type"];
-  $radio_group_name = "carcode_wp_plugin_settings[carcode_wp_plugin_widget_type]";
-?>
-  <input id="id_widget_type" type="radio" name="<?= $radio_group_name; ?>" value="dealerId" <?= checked("dealerId", $widget_type_option) ?>>
-  <label for="id_widget_type">Dealer Id</label><br />
-  <input id="slug_widget_type" type="radio" name="<?= $radio_group_name; ?>" value="slugId" <?= checked("slugId", $widget_type_option)?>>
-  <label for="slug_widget_type">Widget Slug Id</label>
-<?php
+    $options = get_option("carcode_wp_plugin_settings");
+    $widget_type_option = $options["carcode_wp_plugin_widget_type"];
+    $radio_group_name = "carcode_wp_plugin_settings[carcode_wp_plugin_widget_type]";
+    ?>
+    <input id="id_widget_type" type="radio" name="<?= $radio_group_name; ?>"
+           value="dealerId" <?= checked("dealerId", $widget_type_option) ?>>
+    <label for="id_widget_type">Dealer Id</label><br/>
+    <input id="slug_widget_type" type="radio" name="<?= $radio_group_name; ?>"
+           value="slugId" <?= checked("slugId", $widget_type_option) ?>>
+    <label for="slug_widget_type">Widget Slug Id</label>
+    <?php
 }
 
 function carcode_wp_plugin_eas_id_render()
 {
-  $options = get_option("carcode_wp_plugin_settings");
-  $eas_id_setting = sanitize_text_field($options["carcode_wp_plugin_eas_id"]);
-?>
-  <input type="text" name="carcode_wp_plugin_settings[carcode_wp_plugin_eas_id]" value="<?= $eas_id_setting; ?>">
-  <span>(leave blank to disable)</span>
-<?php
+    $options = get_option("carcode_wp_plugin_settings");
+    $eas_id_setting = sanitize_text_field($options["carcode_wp_plugin_eas_id"]);
+    ?>
+    <input type="text" name="carcode_wp_plugin_settings[carcode_wp_plugin_eas_id]" value="<?= $eas_id_setting; ?>">
+    <span>(leave blank to disable)</span>
+    <?php
 }
 
 
 function carcode_wp_plugin_carcode_id_render()
 {
-  $options = get_option("carcode_wp_plugin_settings");
-  $carcode_id_setting = sanitize_text_field($options["carcode_wp_plugin_carcode_id"]);
-?>
-  <input type="text" name="carcode_wp_plugin_settings[carcode_wp_plugin_carcode_id]" value="<?= $carcode_id_setting; ?>">
-  <span>(leave blank to disable)</span>
-<?php
+    $options = get_option("carcode_wp_plugin_settings");
+    $carcode_id_setting = sanitize_text_field($options["carcode_wp_plugin_carcode_id"]);
+    ?>
+    <input type="text" name="carcode_wp_plugin_settings[carcode_wp_plugin_carcode_id]"
+           value="<?= $carcode_id_setting; ?>">
+    <span>(leave blank to disable)</span>
+    <?php
 }
+
+function carcode_wp_plugin_skip_button_mobile_id_render()
+{
+    $options = get_option("carcode_wp_plugin_settings");
+    $skip_button_mobile_setting = $options["carcode_wp_plugin_skip_button_mobile_id"];
+    ?>
+    <input
+            type="checkbox"
+            name="carcode_wp_plugin_settings[carcode_wp_plugin_skip_button_mobile_id]"
+        <?php checked($skip_button_mobile_setting, '1'); ?>
+    >
+    <span>(The widget will be hidden on mobile screens but will still display on desktop)</span>
+    <span><?= $skip_button_mobile_setting ?></span>
+    <?php
+}
+
 
 function carcode_wp_plugin_settings_section_callback()
 {
-  echo <<<EOT
+    echo <<<EOT
 <p>Thank you for using the CarCode WordPress Plugin. This plugin allows you to add the CarCode widget script<br/>
 to your wordpress site as well as the Content-Container script.</p>
 
@@ -172,64 +207,78 @@ To disable the CarCode widget leave the CarCode ID text box blank.</p>
 To enable the Content-Container (EAS) script add the provided Content-Container ID in the EAS ID text box.<br/>
 To disable the Content-Container (EAS) script leave the EAS ID text box blank.
 </p>
+<p>
+To hide the widget on mobile check the 'Skip button on Mobile' option.
+<em>This only affects the mobile widget and does not affect the desktop widget.</em>
+</p>
 EOT;
 }
 
 function carcode_wp_plugin_options_page()
 {
-?>
-  <form action="options.php" method="post">
-    <?php
-    settings_fields("carcode_wp_plugin_page");
-    do_settings_sections("carcode_wp_plugin_page");
-    submit_button();
     ?>
-  </form>
-<?php
+    <form action="options.php" method="post">
+        <?php
+        settings_fields("carcode_wp_plugin_page");
+        do_settings_sections("carcode_wp_plugin_page");
+        submit_button();
+        ?>
+    </form>
+    <?php
 }
 
 function carcode_wp_plugin_build_carcode_url($type)
 {
-  $url = "https://www.carcodesms.com/widgets/";
+    $url = "https://www.carcodesms.com/widgets/";
 
-  if ($type == "slug") {
-    $url .= "s/";
-  }
+    if ($type == "slug") {
+        $url .= "s/";
+    }
 
-  return $url;
+    return $url;
 }
 
 function carcode_wp_plugin_info()
 {
-  $options = get_option("carcode_wp_plugin_settings");
-  $eas_id_setting = $options["carcode_wp_plugin_eas_id"];
-  $widget_type_setting = $options["carcode_wp_plugin_widget_type"];
-  $carcode_id_setting = $options["carcode_wp_plugin_carcode_id"];
-?>
-  <script type="text/javascript">
-    window.__carcode_wp_plugin = {
-      version: 'v1.2.0',
-     easId: '<?= isset($eas_id_setting) && !empty($eas_id_setting) ? $eas_id_setting : "No EAS id set" ?>',
-      widgetType: '<?= isset($widget_type_setting) && !empty($widget_type_setting) ? $widget_type_setting : "No widget type set" ?>',
-      carcodeId: '<?= isset($carcode_id_setting) && !empty($carcode_id_setting) ? $carcode_id_setting : "No CarCode id set" ?>'
-    }
-  </script>
-  <?php
+    $options = get_option("carcode_wp_plugin_settings");
+    $eas_id_setting = $options["carcode_wp_plugin_eas_id"];
+    $widget_type_setting = $options["carcode_wp_plugin_widget_type"];
+    $carcode_id_setting = $options["carcode_wp_plugin_carcode_id"];
+    $skip_button_mobile_setting = isset($options["carcode_wp_plugin_skip_button_mobile_id"]) ? $options["carcode_wp_plugin_skip_button_mobile_id"] : '0';
+    ?>
+    <script type="text/javascript">
+        window.__carcode_wp_plugin = {
+            version: 'v1.3.0',
+            easId: '<?= isset($eas_id_setting) && !empty($eas_id_setting) ? esc_js($eas_id_setting) : "No EAS id set" ?>',
+            widgetType: '<?= isset($widget_type_setting) && !empty($widget_type_setting) ? esc_js($widget_type_setting) : "No widget type set" ?>',
+            carcodeId: '<?= isset($carcode_id_setting) && !empty($carcode_id_setting) ? esc_js($carcode_id_setting) : "No CarCode id set" ?>',
+            skipButtonMobile: '<?= $skip_button_mobile_setting === '1' ? "yes" : "no" ?>',
+        };
+
+    window.__carcode = {
+        <?php if ($skip_button_mobile_setting === '1') { ?>  
+            skipButton: <?= wp_is_mobile() ? 'true' : 'false'; ?>,
+        <?php } ?>
+    };
+
+    </script>
+    <?php
 }
 
 function carcode_wp_plugin_add_eas_js_snippet()
 {
-  $options = get_option("carcode_wp_plugin_settings");
-  $eas_id_setting = sanitize_text_field($options["carcode_wp_plugin_eas_id"]);
-  if (isset($eas_id_setting) && !empty($eas_id_setting)) {
-  ?>
-    <script src="https://content-container.edmunds.com/<?= $eas_id_setting; ?>.js" type="text/javascript" async defer</script>
-      <?php
+    $options = get_option("carcode_wp_plugin_settings");
+    $eas_id_setting = sanitize_text_field($options["carcode_wp_plugin_eas_id"]);
+    if (isset($eas_id_setting) && !empty($eas_id_setting)) {
+        ?>
+        <script src="https://content-container.edmunds.com/<?= $eas_id_setting; ?>.js" type="text/javascript" async
+                defer</script>
+        <?php
     }
-  }
+}
 
-  function carcode_wp_plugin_add_carcode_js_snippet()
-  {
+function carcode_wp_plugin_add_carcode_js_snippet()
+{
     $options = get_option("carcode_wp_plugin_settings");
     $carcode_id_setting = sanitize_text_field($options["carcode_wp_plugin_carcode_id"]);
     $widget_type_setting = $options["carcode_wp_plugin_widget_type"];
@@ -238,12 +287,12 @@ function carcode_wp_plugin_add_eas_js_snippet()
 
 
     if (isset($carcode_id_setting) && !empty($carcode_id_setting)) {
-      ?> 
-      <script src="<?= $url . $carcode_id_setting; ?>.js" type = "text/javascript" async defer ></script>
+        ?>
+        <script src="<?= $url . $carcode_id_setting; ?>.js" type="text/javascript" async defer></script>
         <?php
-      }
-  }
+    }
+}
 
-  add_action("wp_head", "carcode_wp_plugin_add_carcode_js_snippet", 3);
-  add_action("wp_head", "carcode_wp_plugin_add_eas_js_snippet", 4);
-  add_action("wp_head", "carcode_wp_plugin_info", 10);
+add_action("wp_head", "carcode_wp_plugin_add_carcode_js_snippet", 3);
+add_action("wp_head", "carcode_wp_plugin_add_eas_js_snippet", 4);
+add_action("wp_head", "carcode_wp_plugin_info", 10);


### PR DESCRIPTION
This adds a checkbox to enable "Skip Button" when wordpress detects a mobile viewport/device. 

If 'Skip button on mobile' is checked then `skipButton` is added to the `window.__carcode` config object.
Next, if wordpress detects a mobile device/viewport then it sets `skipButton` to `true` otherwise it sets `skipButton` to false. 

This ensures the widget is hidden on mobile but visible on desktop.

These values can be overwritten by adding `window.__carcode` options manually in the appropriate custom JS block in Wordpress.